### PR TITLE
Add field types to datasets

### DIFF
--- a/boonai/model.py
+++ b/boonai/model.py
@@ -63,6 +63,8 @@ class Dataset(db.Model):
     description = db.Column(db.String(1000))
     train = db.Column(db.Boolean)
     test = db.Column(db.Boolean)
+    features_type = db.Column(db.String(20))
+    labels_type = db.Column(db.String(20))
     label = db.Column(db.Boolean)
     project_id = db.Column(db.Integer)
     user_id = db.Column(db.Integer)

--- a/boonai/project/api/datasets.py
+++ b/boonai/project/api/datasets.py
@@ -74,6 +74,8 @@ class All(Resource):
             user_id=posted_json['user_id'],
             train=posted_json['train'],
             test=posted_json['test'],
+            features_type = posted_json['features_type'],
+            labels_type = posted_json['labels_type'],
             label=posted_json['label'],
             project_id=posted_json['project_id'],
             file_id=posted_json['file_id']

--- a/boonai/project/site/dataprep.py
+++ b/boonai/project/site/dataprep.py
@@ -54,6 +54,7 @@ class FilterForm(FlaskForm):
 
 
 class SubmitProcessed(FlaskForm):
+    dropdown_list = [('text', 'Text'), ('numeric', 'Numeric'),('mixed', 'Mixed')]
     name = StringField(
         'Dataset Name',
         [Length(min=5, max=25)]
@@ -71,6 +72,8 @@ class SubmitProcessed(FlaskForm):
     label = BooleanField(
         'Label',
     )
+    features_type = SelectField('Features type', choices=dropdown_list, default=1)
+    labels_type = SelectField('Labels type', choices=dropdown_list, default=1)
 
 
 def _get_link(links, rel_value):
@@ -373,7 +376,7 @@ def upload_proc_get():
     )
 
 
-def upload_dataset(file, name, description, train, test, label):
+def upload_dataset(file, name, description, train, test, features_type, labels_type, label):
     datasets_api_url = current_app.config['DATASETS_API']
     storage_api_url = current_app.config['STORAGE_API']
     try:
@@ -393,6 +396,8 @@ def upload_dataset(file, name, description, train, test, label):
         'train': train,  # TODO: maybe it can just accept true false
         'test': test,
         'label': label,
+        'features_type': features_type,
+        'labels_type': labels_type,
         'file_id': int(r.text),
         'user_id': current_user.id,
         'project_id': 0
@@ -425,6 +430,8 @@ def upload_proc_post():
             description=form.description.data,
             train= form.train.data,
             test=form.test.data,
+            features_type=form.features_type.data,
+            labels_type=form.labels_type.data,
             label=form.label.data
         )
 

--- a/boonai/project/site/machine_learning.py
+++ b/boonai/project/site/machine_learning.py
@@ -193,6 +193,8 @@ def train():
 
         dataset_id = form.dataset.data
         algorithm_id = form.algorithm.data
+        # Get name of selected algorythm
+        algorithm_name = dict(form.algorithm.choices).get(form.algorithm.data)
 
         model_api_url = current_app.config['MODELS_API']
         json_request = {


### PR DESCRIPTION
First commit for issue #10 

I am thinking about modifying how models are displayed to generate list of available algorithm after train page is displayed.
With dictionary created upfront we can't change type after data set is changed on train page.